### PR TITLE
Production security values.

### DIFF
--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -322,7 +322,7 @@ DocumentRoot "/var/www/html"
 # http://httpd.apache.org/docs/2.2/mod/core.html#options
 # for more information.
 #
-    Options Indexes FollowSymLinks
+    Options -Indexes +FollowSymLinks
 
 #
 # AllowOverride controls what directives may be placed in .htaccess files.
@@ -545,7 +545,7 @@ ServerSignature On
 Alias /icons/ "/var/www/icons/"
 
 <Directory "/var/www/icons">
-    Options Indexes MultiViews FollowSymLinks
+    Options -Indexes +MultiViews +FollowSymLinks
     AllowOverride None
     Order allow,deny
     Allow from all
@@ -1001,3 +1001,6 @@ NameVirtualHost *:<%= @apacheport %>
 #    ErrorLog logs/dummy-host.example.com-error_log
 #    CustomLog logs/dummy-host.example.com-access_log common
 #</VirtualHost>
+
+ServerSignature Off
+ServerTokens Prod

--- a/templates/php.ini.apache2.erb
+++ b/templates/php.ini.apache2.erb
@@ -428,7 +428,7 @@ disable_classes =
 ; threat in any way, but it makes it possible to determine whether you use PHP
 ; on your server or not.
 ; http://php.net/expose-php
-expose_php = On
+expose_php = Off
 
 ;;;;;;;;;;;;;;;;;;;
 ; Resource Limits ;


### PR DESCRIPTION
On production servers it is nice to expose as little data as possible about the
platform and versions running things. Bot-style attacks often look for certain
fingerprints to decide to continue an attack like a vulerability on a specific
Ubuntu or PHP version. On production sites we can limit this information.
- Do not show indexes for directories.
- Hide Apache version number.
- Do not show OS information in Apache responses.
- Hide PHP information in responses.
